### PR TITLE
uses channels for concurrent entity processing

### DIFF
--- a/cmd/entity.go
+++ b/cmd/entity.go
@@ -78,11 +78,7 @@ func execEntityCmd(ldifParser ldsview.LdifParser, keyAttr string, keyValue strin
 		return
 	}
 
-	if parseTdc {
-		entity.DeocdeTimestamps()
-	}
-
-	PrintEntity(entity)
+	PrintEntity(entity, parseTdc)
 }
 
 func init() {

--- a/cmd/structure.go
+++ b/cmd/structure.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"sort"
 
-	"github.com/spf13/cobra"
 	ldsview "github.com/kgoins/ldsview/pkg"
 )
 

--- a/pkg/entity_source.go
+++ b/pkg/entity_source.go
@@ -5,8 +5,6 @@ import "github.com/kgoins/ldsview/internal"
 // EntitySource returns LDAP Entites constructed from an input data source.
 // If filter values are not set, they will default to empty lists. Null values will cause a panic.
 type EntitySource interface {
-	CountEntities() (int, error)
-
 	BuildEntity(keyAttrName string, keyAttrVal string) (Entity, error)
 	BuildEntities() ([]Entity, error)
 

--- a/pkg/structure_builder_test.go
+++ b/pkg/structure_builder_test.go
@@ -2,17 +2,16 @@ package ldsview
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStructureBuilder_GetStructure(t *testing.T) {
 	parser := NewLdifParser(TESTFILE)
 
-	structure, err := GetStructure(&parser)
-	if err != nil {
-		t.Fatalf("failed to parse ldif for domain structure")
-	}
-
-	if len(structure) == 0 {
-		t.Fatalf("failed to parse ldif for domain structure")
-	}
+	t.Run("parses the ldif objects correctly", func(t *testing.T) {
+		structure, err := GetStructure(&parser)
+		assert.Nil(t, err)
+		assert.Greater(t, len(structure), 0)
+	})
 }

--- a/pkg/uac.go
+++ b/pkg/uac.go
@@ -10,6 +10,29 @@ import (
 	"github.com/audibleblink/msldapuac"
 )
 
+type UACFilter struct {
+	searchProp int
+}
+
+func NewUACFilter(searchTerm int) UACFilter {
+	return UACFilter{searchProp: searchTerm}
+}
+
+func (filter UACFilter) Matches(entity Entity) (isMatch bool) {
+	uacAttr, found := entity.GetAttribute("userAccountControl")
+	if found {
+		uacString := uacAttr.Value.GetSingleValue()
+		uac, _ := strconv.ParseInt(uacString, 10, 32)
+		isMatch, err := msldapuac.IsSet(uac, filter.searchProp)
+		if err != nil {
+			fmt.Printf("Unable to verify UAC: %v\n", err.Error())
+			return false
+		}
+		return isMatch
+	}
+	return
+}
+
 // GetFlagsFromUAC wraps teh msldapuac dependency for easy re-definition
 func GetFlagsFromUAC(uac int64) ([]string, error) {
 	return msldapuac.ParseUAC(uac)

--- a/testdata/test_users.ldif
+++ b/testdata/test_users.ldif
@@ -35,7 +35,47 @@ objectSid:: AQUAAAAAAAUVAAAAa9ZiBBbA6jKDPStVYiIMAA==
 accountExpires: 9223372036854775807
 sAMAccountName: MYUSR
 sAMAccountType: 805306368
+servicePrincipalName: HTTP/MYUSR
 userPrincipalName: MYUSR@contoso.com
+lockoutTime: 0
+objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=contoso,DC=com
+dSCorePropagationData: 20190827201429.0Z
+dSCorePropagationData: 20190529140155.0Z
+dSCorePropagationData: 20190407190910.0Z
+dSCorePropagationData: 20190311163932.0Z
+dSCorePropagationData: 16010714223649.0Z
+lastLogonTimestamp: 130674899604502606
+
+# DISABLEDUSER, ContosoUsers, contoso.com
+dn: CN=DISABLEDUSER,OU=ContosoUsers,DC=contoso,DC=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: user
+cn: DISABLEDUSER
+givenName: DISABLEDUSER
+distinguishedName: CN=DISABLEDUSER,OU=ContosoUsers,DC=contoso,DC=com
+instanceType: 4
+whenCreated: 20120423175240.0Z
+whenChanged: 20190225044802.0Z
+displayName: DISABLEDUSER
+uSNCreated: 793245
+memberOf: CN=vault_users,OU=Global,OU=Security,OU=Groups,DC=contoso,DC=com
+memberOf: CN=PWD Complexity,OU=Security,OU=Groups,DC=contoso,DC=com
+uSNChanged: 1076364863
+name: DISABLEDUSER
+objectGUID:: 7OBfD10nQkSVYY8UHCV2aQ==
+userAccountControl: 66050
+codePage: 0
+countryCode: 0
+pwdLastSet: 129857191591306845
+primaryGroupID: 805306368
+objectSid:: AQUAAAAAAAUVAAAAa9ZiBBbA6jKDPStVYiIMAA==
+accountExpires: 9223372036854775807
+sAMAccountName: DISABLEDUSER
+sAMAccountType: 805306368
+servicePrincipalName: HTTP/DISABLEDUSER
+userPrincipalName: DISABLEDUSER@contoso.com
 lockoutTime: 0
 objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=contoso,DC=com
 dSCorePropagationData: 20190827201429.0Z
@@ -73,6 +113,7 @@ objectSid:: AQUAAAAAAAUVAAAAa9ZiBBbA6jKDPStVYiIMAA==
 accountExpires: 9223372036854775807
 sAMAccountName: MYPC
 sAMAccountType: 805306368
+servicePrincipalName: HOST/MYPC
 userPrincipalName: MYPC@contoso.com
 lockoutTime: 0
 objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=contoso,DC=com


### PR DESCRIPTION
  * use seperate channels for entity parsing
  * use a "print queue" to consume the matched entities channel
  * print entities as they're found
  * modify the `spn`, `count`, `uac`, and `structure` subcmds to use
    channels
  * implement UAC IEntityFilter to match the rest of the code base
  * add disabled user to fixtures
  * fixes test for new code