### PR TITLE
ldif splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,28 @@ Detailed usage information is available via the `--help` flag or the `help` comm
     * This command will return all entities with an `adminCount` of 1 that are not `krbtgt`
     * `-i` can be used to limit which attributes are returned from matching entities
     * `--tdc` will translate directory timestamps into a human readable format
+
+
+### Tools Directory
+
+Additional tools and utilities for managing LDIFs:
+
+***Makefile***: Place the Makefile in the same directory as your exported LDIF and run make.
+
+```sh
+>> make -j9 LDIF=./my.domain.ldif
+```
+This will split and create the following default LDIFs:
+
+* users.ldif
+* computers.ldif
+* groups.ldif
+* domain_admin.ldif
+* poss_svc_accnts.ldif
+* pass_not_reqd.ldif
+* pass_cant_change.ldif
+* users_dont_expire.ldif
+* trusted_4_delegation.ldif
+* preauth_not_reqd.ldif
+* password_expired.ldif
+* trust2auth4delegation.ldif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,41 @@
+LDIF ?= dump.ldif
+SEARCH = ldsview -f "${LDIF}" search
+UAC = ldsview -f "${LDIF}" uac --search
+
+query.users = objectClass:=user,objectClass:!=computer
+query.computers = objectClass:=computer
+query.groups = objectClass:=group
+query.domain_admin = cn:~Domain Admins
+query.poss_svc_accnts = sAMAccountName:~svc
+
+query.pass_not_reqd = 32
+query.pass_cant_change = 64
+query.users_dont_expire = 65536
+query.trusted_4_delegation = 524288
+query.preauth_not_reqd = 4194304
+query.password_expired = 8388608
+query.trust2auth4delegation = 16777216
+
+SEARCH_TARGETS = users \
+          computers \
+          groups \
+          domain_admin \
+          poss_svc_accnts
+
+UAC_TARGETS = pass_not_reqd \
+          pass_cant_change \
+          users_dont_expire \
+          trusted_4_delegation \
+          preauth_not_reqd \
+          password_expired \
+          trust2auth4delegation
+
+target=$(word 1, $@)
+
+all: ${SEARCH_TARGETS} ${UAC_TARGETS}
+
+${SEARCH_TARGETS}:
+        ${SEARCH} "${query.${target}}" > "${target}.ldif"
+
+${UAC_TARGETS}:
+        ${UAC} "${query.${target}}" > "${target}.ldif"


### PR DESCRIPTION
draft proposal for #26 

Using a makefile to split the LDIF allows for easier customization by users to designate how they want LDIFs split. 
Make also gives us free concurrency with the `-j` flag here